### PR TITLE
Issue #12 - Don't query full `details` blob. Skip the view for now.

### DIFF
--- a/src/client/components/user_report_contents.tsx
+++ b/src/client/components/user_report_contents.tsx
@@ -82,7 +82,7 @@ export default function UserReportContents({ index, report }: UserReportContents
             )}
             <tr>
               <td>User Agent</td>
-              <td>{report.details.browser_info.app.default_useragent_string}</td>
+              <td>{report.ua_string}</td>
             </tr>
             {report.related_bugs?.length > 0 && (
               <tr>
@@ -97,17 +97,6 @@ export default function UserReportContents({ index, report }: UserReportContents
                       </li>
                     ))}
                   </ul>
-                </td>
-              </tr>
-            )}
-            {report.details && (
-              <tr>
-                <td>Full Details</td>
-                <td>
-                  <details>
-                    <summary>Show full details as JSON</summary>
-                    <pre>{JSON.stringify(report.details, null, 2)}</pre>
-                  </details>
                 </td>
               </tr>
             )}

--- a/src/server/routes/user_reports.ts
+++ b/src/server/routes/user_reports.ts
@@ -20,22 +20,32 @@ export default async function handleUserReports(req: Request, res: Response) {
     const [[rawReports], [rawUrlPatterns]] = await Promise.all([
       bq.query({
         query: `
-          SELECT reports.*,
+          SELECT
+            reports.document_id AS uuid,
+            CAST(reports.submission_timestamp AS DATETIME) AS reported_at,
+            reports.client_info.app_display_version AS app_version,
+            reports.metrics.string.broken_site_report_breakage_category AS breakage_category,
+            reports.metrics.text2.broken_site_report_browser_info_app_default_useragent_string as ua_string,
+            reports.metrics.text2.broken_site_report_description AS comments,
+            reports.metrics.url2.broken_site_report_url AS url,
+            reports.normalized_app_name AS app_name,
+            reports.normalized_channel AS app_channel,
+            reports.normalized_os AS os,
             ARRAY(
               SELECT label
               FROM webcompat_user_reports.labels
-              WHERE report_uuid = reports.uuid
+              WHERE report_uuid = reports.document_id
             ) as labels,
             bp.label as prediction,
             bp.probability as prob
-          FROM webcompat_user_reports.user_reports_prod as reports
-          LEFT JOIN webcompat_user_reports.bugbug_predictions AS bp ON reports.uuid = bp.report_uuid
+          FROM moz-fx-data-shared-prod.firefox_desktop.broken_site_report as reports
+          LEFT JOIN webcompat_user_reports.bugbug_predictions AS bp ON reports.document_id = bp.report_uuid
           WHERE
-            reports.reported_at BETWEEN ? and DATE_ADD(?, interval 1 day)
+            reports.submission_timestamp BETWEEN TIMESTAMP(?) and TIMESTAMP(DATE_ADD(?, interval 1 day))
 
             # Exclude reports that have a tracked action, i.e. reports hidden
             # or reports that have been investigated
-            AND NOT EXISTS (SELECT 1 FROM webcompat_user_reports.report_actions WHERE report_actions.report_uuid = reports.uuid)
+            AND NOT EXISTS (SELECT 1 FROM webcompat_user_reports.report_actions WHERE report_actions.report_uuid = reports.document_id)
             ORDER BY 
             CASE
               WHEN prediction = 'valid' THEN 1
@@ -80,9 +90,6 @@ export default async function handleUserReports(req: Request, res: Response) {
         // actually an object {value: "[timestamp]"}.
         // [ToDo] figure out why, and if this is something that could change
         newReport.reported_at = (report as any).reported_at.value;
-
-        // Details are stored as JSON-as-String, so let's parse
-        newReport.details = JSON.parse(report.details as any);
 
         newReport.related_bugs = preprocessedUrlPatterns
           .filter((pattern) => report.url.includes(pattern.url_pattern))

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,7 +4,7 @@ export type UserReport = {
   url: string;
   breakage_category?: string;
   comments: string;
-  details: Record<string, any>;
+  ua_string: string;
   related_bugs: RelatedBug[];
   labels: string[];
   prediction: string;


### PR DESCRIPTION
This isn't a full perf solution, but it's a small step. We don't need the full JSON blob anyway, we can just query data as needed. This is also skipping the view for now. I explained why in #12, but I'm quoting here just for posterity and discoverability:

> The thinking here was that we do a lot of processing in the view, namely building that JSON blob from actual columns. The idea here was to match the format from the old reporter, but we don't need that anymore, so we should just remove that.

This is probably only a temporary thing, and we might need a view in the future anyway (especially if there's more than just Desktop). But for now, I think it's good to avoid doing unnecessary work.

r? @ksy36 
fyi! @moztcampbell 