### PR TITLE
Issue #14 - Don't use `ViteExpress` in production.

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -148,4 +148,8 @@ const server = app.listen(listenPort, () => {
   console.log(`Listening to 0.0.0.0:${listenPort}`);
 });
 
-ViteExpress.bind(app, server);
+if (process.env.NODE_ENV == "production") {
+  app.use(express.static("dist/"));
+} else {
+  ViteExpress.bind(app, server);
+}


### PR DESCRIPTION
This was a bit of an oversight on my end. The container image already builds the frontend assets into `dist/`:

https://github.com/mozilla/webcompat-dashboard/blob/ee42d5e3601a9570d09fc976ccc8c2e4c8c9dee8/Dockerfile#L20-L21

but we're still using `ViteExpress` in production. This has a huge memory cost (see #14), and there is no reason to do that. The container images command is calling `npm start`, so we're always have the `NODE_ENV` var set correctly in prod:

https://github.com/mozilla/webcompat-dashboard/blob/ee42d5e3601a9570d09fc976ccc8c2e4c8c9dee8/package.json#L11

so this is an easy fix that requires no other changes. This closes #14.

r? @ksy36 
fyi! @moztcampbell 