### PR TITLE
Don't send an empty message in the access log json.

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -51,7 +51,7 @@ app.use(
     },
     {
       stream: {
-        write: (message) => logger.info("", Object.assign({ log_type: "access" }, JSON.parse(message))),
+        write: (message) => logger.info(undefined!, Object.assign({ log_type: "access" }, JSON.parse(message))),
       },
     },
   ),


### PR DESCRIPTION
I initially didn't do it because `undefined` is imcompatible with the type signature, but if we have an empty string as a message in the JSON blob, Logs Explorer just displays an empty string, instead of showing the JSON...

The new access log lines look like

```json
{"level":"info","log_type":"access","remote_addr":"::ffff:127.0.0.1","request":"GET /__heartbeat__ HTTP/1.1","request_time":"1.913","status":"200","timestamp":"2024-04-10T14:15:23.974Z","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0"}
```

Which is still the same, except that there's no more `"message":""`.