### PR TITLE
Memoize PSL lookup function to speed it up

### DIFF
--- a/src/server/helpers/user_reports_transform.ts
+++ b/src/server/helpers/user_reports_transform.ts
@@ -43,11 +43,14 @@ export function transformUserReports(rawReports: any[], rawUrlPatterns: any[], l
     });
 
   logger.verbose("Grouping reports by root domain...");
+  let normalizeHostname = _.memoize((hostname: string) => {
+    const parsedDomain = psl.parse(hostname);
+    return (parsedDomain as psl.ParsedDomain).domain || "[unknown]";
+  });
   const groupedByDomain = _.groupBy(preprocessedReports, (report) => {
     try {
       const parsedUrl = new URL(report.url);
-      const parsedDomain = psl.parse(parsedUrl.hostname);
-      return (parsedDomain as psl.ParsedDomain).domain || "[unknown]";
+      return normalizeHostname(parsedUrl.hostname);
     } catch {
       return "[unknown]";
     }


### PR DESCRIPTION
When using PSL to convert user_report hostnames to canonical domain, we only care about limited set of functionality. This combined with multiple reports per hostname means that a simple _.memoize wrapper speeds up the domain grouping.