### PR TITLE
Move BigQuery call for user_reports to same Worker thread that data is analyzed on

### DIFF
--- a/src/server/helpers/user_reports_transform.ts
+++ b/src/server/helpers/user_reports_transform.ts
@@ -1,8 +1,73 @@
 import { parentPort, workerData } from "node:worker_threads";
 import _ from "underscore";
 import psl from "psl";
+import { getBqConnection } from "../helpers/bigquery";
 import { UrlPattern, UserReport } from "../../shared/types";
 import type { Logger } from "winston";
+
+export async function fetchUserReports(paramFrom: string, paramTo: string, logger: Logger) {
+  logger.verbose("Connecting to BigQuery...");
+  const bq = getBqConnection();
+
+  logger.verbose("Starting queries...");
+  // Note: this looks weird - but it makes sure the queries run in parallel.
+  // Since BQ has some initial latency when responding, this matters.
+  // [ToDo] Investigate whether using QueryJobs makes sense here.
+  const [[rawReports], [rawUrlPatterns]] = await Promise.all([
+    bq.query({
+      query: `
+        SELECT
+          reports.document_id AS uuid,
+          CAST(reports.submission_timestamp AS DATETIME) AS reported_at,
+          reports.client_info.app_display_version AS app_version,
+          reports.metrics.string.broken_site_report_breakage_category AS breakage_category,
+          reports.metrics.text2.broken_site_report_browser_info_app_default_useragent_string as ua_string,
+          reports.metrics.text2.broken_site_report_description AS comments,
+          reports.metrics.url2.broken_site_report_url AS url,
+          reports.normalized_app_name AS app_name,
+          reports.normalized_channel AS app_channel,
+          reports.normalized_os AS os,
+          ARRAY(
+            SELECT label
+            FROM webcompat_user_reports.labels
+            WHERE report_uuid = reports.document_id
+          ) as labels,
+          bp.label as prediction,
+          bp.probability as prob
+        FROM moz-fx-data-shared-prod.firefox_desktop.broken_site_report as reports
+        LEFT JOIN webcompat_user_reports.bugbug_predictions AS bp ON reports.document_id = bp.report_uuid
+        WHERE
+          reports.submission_timestamp BETWEEN TIMESTAMP(?) and TIMESTAMP(DATE_ADD(?, interval 1 day))
+
+          # Exclude reports that have a tracked action, i.e. reports hidden
+          # or reports that have been investigated
+          AND NOT EXISTS (SELECT 1 FROM webcompat_user_reports.report_actions WHERE report_actions.report_uuid = reports.document_id)
+          ORDER BY
+          CASE
+            WHEN prediction = 'valid' THEN 1
+            WHEN prediction = 'invalid' THEN 2
+            ELSE 3
+          END,
+            CASE WHEN prediction = 'valid' THEN prob END DESC,
+            CASE WHEN prediction = 'invalid' THEN prob END ASC;
+      `,
+      params: [paramFrom, paramTo],
+    }),
+    bq.query({
+      query: [
+        "SELECT patterns.*, bugs.title",
+        "FROM webcompat_knowledge_base.url_patterns AS patterns",
+        "LEFT JOIN webcompat_knowledge_base.bugzilla_bugs AS bugs ON patterns.bug = bugs.number",
+      ].join(" "),
+    }),
+  ]);
+  logger.verbose(`Received ${rawReports.length} user reports and ${rawUrlPatterns.length} URL patterns.`);
+
+  return {
+    rawReports,
+    rawUrlPatterns,
+  };
+}
 
 export function transformUserReports(rawReports: any[], rawUrlPatterns: any[], logger: Logger) {
   logger.verbose("Pre-processing URL patterns...");
@@ -73,16 +138,23 @@ export function transformUserReports(rawReports: any[], rawUrlPatterns: any[], l
   return JSON.stringify(sorted);
 }
 
-// If this module is used in a worker, automatically call the transform
-// code using the `workerData` as arguments and post back the result.
+// If this module is used in a worker, automatically fetch data from
+// BigQuery and transform the result. Using `workerData` for parameters
+// and posting result back to parent.
 if (parentPort) {
+  // Logging posts messages back to main-thread to avoid multithreading
+  // issues of sharing stdout.
   const logger = {
     verbose(msg: string) {
       parentPort?.postMessage({ type: "verbose", msg });
     },
   };
 
-  const { rawReports, rawUrlPatterns } = workerData;
-  const result = transformUserReports(rawReports, rawUrlPatterns, logger);
-  parentPort?.postMessage({ type: "done", result });
+  // Use an async context to do processing, posting the result back
+  // to parent whenever it is done.
+  (async function ({ paramFrom, paramTo }) {
+    const { rawReports, rawUrlPatterns } = await fetchUserReports(paramFrom, paramTo, logger);
+    const result = transformUserReports(rawReports, rawUrlPatterns, logger);
+    parentPort?.postMessage({ type: "done", result });
+  })(workerData);
 }

--- a/src/server/routes/user_reports.ts
+++ b/src/server/routes/user_reports.ts
@@ -4,7 +4,6 @@ import { Request, Response } from "express";
 import type { Logger } from "winston";
 
 import { endWithStatusAndBody, getParsedUrl } from "../helpers/http";
-import { getBqConnection } from "../helpers/bigquery";
 
 export default async function handleUserReports(logger: Logger, req: Request, res: Response) {
   const childLogger = logger.child({ handler: "handleUserReports" });
@@ -15,67 +14,11 @@ export default async function handleUserReports(logger: Logger, req: Request, re
     return endWithStatusAndBody(res, 400, "`from` and `to` query parameters required");
   }
 
-  childLogger.verbose("Connecting to BigQuery...");
-  const bq = getBqConnection();
   try {
-    childLogger.verbose("Starting queries...");
-    // Note: this looks weird - but it makes sure the queries run in parallel.
-    // Since BQ has some initial latency when responding, this matters.
-    // [ToDo] Investigate whether using QueryJobs makes sense here.
-    const [[rawReports], [rawUrlPatterns]] = await Promise.all([
-      bq.query({
-        query: `
-          SELECT
-            reports.document_id AS uuid,
-            CAST(reports.submission_timestamp AS DATETIME) AS reported_at,
-            reports.client_info.app_display_version AS app_version,
-            reports.metrics.string.broken_site_report_breakage_category AS breakage_category,
-            reports.metrics.text2.broken_site_report_browser_info_app_default_useragent_string as ua_string,
-            reports.metrics.text2.broken_site_report_description AS comments,
-            reports.metrics.url2.broken_site_report_url AS url,
-            reports.normalized_app_name AS app_name,
-            reports.normalized_channel AS app_channel,
-            reports.normalized_os AS os,
-            ARRAY(
-              SELECT label
-              FROM webcompat_user_reports.labels
-              WHERE report_uuid = reports.document_id
-            ) as labels,
-            bp.label as prediction,
-            bp.probability as prob
-          FROM moz-fx-data-shared-prod.firefox_desktop.broken_site_report as reports
-          LEFT JOIN webcompat_user_reports.bugbug_predictions AS bp ON reports.document_id = bp.report_uuid
-          WHERE
-            reports.submission_timestamp BETWEEN TIMESTAMP(?) and TIMESTAMP(DATE_ADD(?, interval 1 day))
-
-            # Exclude reports that have a tracked action, i.e. reports hidden
-            # or reports that have been investigated
-            AND NOT EXISTS (SELECT 1 FROM webcompat_user_reports.report_actions WHERE report_actions.report_uuid = reports.document_id)
-            ORDER BY 
-            CASE
-              WHEN prediction = 'valid' THEN 1
-              WHEN prediction = 'invalid' THEN 2
-              ELSE 3
-            END,
-              CASE WHEN prediction = 'valid' THEN prob END DESC,
-              CASE WHEN prediction = 'invalid' THEN prob END ASC;
-        `,
-        params: [searchParams.get("from")!, searchParams.get("to")!],
-      }),
-      bq.query({
-        query: [
-          "SELECT patterns.*, bugs.title",
-          "FROM webcompat_knowledge_base.url_patterns AS patterns",
-          "LEFT JOIN webcompat_knowledge_base.bugzilla_bugs AS bugs ON patterns.bug = bugs.number",
-        ].join(" "),
-      }),
-    ]);
-    childLogger.verbose(`Received ${rawReports.length} user reports and ${rawUrlPatterns.length} URL patterns.`);
-
     const worker = new Worker(path.join(__dirname, "..", "helpers", "user_reports_transform.ts"), {
       workerData: {
-        rawReports,
-        rawUrlPatterns,
+        paramFrom: searchParams.get("from")!,
+        paramTo: searchParams.get("to")!,
       },
     });
 


### PR DESCRIPTION
Instead of transfering BQ data between threads (with structured-clone), do the request on that helper thread. This is to improve main-thread responsiveness so that heartbeats don't fail.