### PR TITLE
Share /user_reports Worker to avoid startup overhead

### DIFF
--- a/src/server/helpers/bigquery.ts
+++ b/src/server/helpers/bigquery.ts
@@ -1,7 +1,9 @@
 import { BigQuery } from "@google-cloud/bigquery";
 
-export function getBqConnection() {
-  return new BigQuery({
-    projectId: process.env.BQ_PROJECT_ID,
-  });
+export function getDefaultProject() {
+  return process.env.BQ_PROJECT_ID;
+}
+
+export function getBqConnection(projectId = getDefaultProject()) {
+  return new BigQuery({ projectId });
 }

--- a/src/server/routes/user_reports.ts
+++ b/src/server/routes/user_reports.ts
@@ -1,10 +1,16 @@
-import { Worker } from "node:worker_threads";
+import { Worker, MessageChannel } from "node:worker_threads";
 import * as path from "node:path";
 import { Request, Response } from "express";
 import type { Logger } from "winston";
-import { getDefaultProject } from "../helpers/bigquery";
 
 import { endWithStatusAndBody, getParsedUrl } from "../helpers/http";
+
+// Create a separate Worker thread to do the requests on since the
+// data processing is CPU intensive and would otherwise interfere
+// with mainthread responsiveness.
+// For now, only a single worker is used though multiple BQ requests
+// can be in-flight on it.
+const worker = new Worker(path.join(__dirname, "..", "helpers", "user_reports_transform.ts"));
 
 export default async function handleUserReports(logger: Logger, req: Request, res: Response) {
   const childLogger = logger.child({ handler: "handleUserReports" });
@@ -16,16 +22,21 @@ export default async function handleUserReports(logger: Logger, req: Request, re
   }
 
   try {
-    const worker = new Worker(path.join(__dirname, "..", "helpers", "user_reports_transform.ts"), {
-      workerData: {
-        projectId: getDefaultProject(),
+    // Post the request to the existing worker, and use a new MessageChannel
+    // to ensure we only see our own results even if other requests are in-flight.
+    const { port1, port2 } = new MessageChannel();
+    worker.postMessage(
+      {
+        type: "fetch",
+        projectId: process.env.BQ_PROJECT_ID,
         paramFrom: searchParams.get("from")!,
         paramTo: searchParams.get("to")!,
+        port: port1,
       },
-    });
-
+      [port1],
+    );
     const results = await new Promise((resolve) => {
-      worker.on("message", (msg) => {
+      port2.on("message", (msg) => {
         if (msg.type == "done") {
           resolve(msg.result);
         } else if (msg.type == "verbose") {

--- a/src/server/routes/user_reports.ts
+++ b/src/server/routes/user_reports.ts
@@ -2,6 +2,7 @@ import { Worker } from "node:worker_threads";
 import * as path from "node:path";
 import { Request, Response } from "express";
 import type { Logger } from "winston";
+import { getDefaultProject } from "../helpers/bigquery";
 
 import { endWithStatusAndBody, getParsedUrl } from "../helpers/http";
 
@@ -17,6 +18,7 @@ export default async function handleUserReports(logger: Logger, req: Request, re
   try {
     const worker = new Worker(path.join(__dirname, "..", "helpers", "user_reports_transform.ts"), {
       workerData: {
+        projectId: getDefaultProject(),
         paramFrom: searchParams.get("from")!,
         paramTo: searchParams.get("to")!,
       },


### PR DESCRIPTION
Reuse the Worker between requests. This adds a listener for a "fetch" message in order to start the BQ fetch and data transform. I create a new `MessageChannel` for each request to make it simple for notifying the correct Promise when the work is done.
This should save a few seconds off each of the requests that was blocked by startup overhead.