### PR TITLE
Add a more advanced bug comment template.

### DIFF
--- a/src/client/components/user_report_contents.tsx
+++ b/src/client/components/user_report_contents.tsx
@@ -151,9 +151,26 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                   <td className="actions">
                     <button
                       onClick={() => {
+                        const comment =
+                          "**Environment:**\n" +
+                          "Operating system:\n" +
+                          "Firefox version:\n\n" +
+                          "**Preconditions:**\n" +
+                          "text\n\n" +
+                          "**Steps to reproduce:**\n" +
+                          `1. Navigate to: ${report.url}\n` +
+                          "2. Step 2\n\n" +
+                          "**Expected Behavior:**\n" +
+                          "text\n\n" +
+                          "**Actual Behavior:**\n" +
+                          "text\n\n" +
+                          "**Notes:**\n" +
+                          "text\n\n---\n\n" +
+                          `Created from webcompat-user-report:${report.uuid}`;
+
                         const searchParams = new URLSearchParams([
                           ["bug_file_loc", report.url],
-                          ["comment", "CHANGE_ME"],
+                          ["comment", comment],
                           ["component", "Site Reports"],
                           ["product", "Web Compatibility"],
                           ["short_desc", `${rootDomain} - CHANGE_ME`],


### PR DESCRIPTION
As per the internal chats. An example Bugzilla link [is this one](https://bugzilla.mozilla.org/enter_bug.cgi?bug_file_loc=https%3A%2F%2Fwww.youtube.com%2F%3Fapp%3Ddesktop%26hl%3Dit%26gl%3Dit&comment=**Environment%3A**%0AOperating+system%3A%0AFirefox+version%3A%0A%0A**Preconditions%3A**%0Atext%0A%0A**Steps+to+reproduce%3A**%0A1.+Navigate+to%3A+https%3A%2F%2Fwww.youtube.com%2F%3Fapp%3Ddesktop%26hl%3Dit%26gl%3Dit%0A2.+Step+2%0A%0A**Expected+Behavior%3A**%0Atext%0A%0A**Actual+Behavior%3A**%0Atext%0A%0A**Notes%3A**%0Atext%0A%0A---%0A%0ACreated+from+webcompat-user-report%3A53e8e0f1-83d1-4528-b47a-d4d91d59a893&component=Site+Reports&product=Web+Compatibility&short_desc=youtube.com+-+CHANGE_ME&status_whiteboard=%5Bwebcompat-source%3Aproduct%5D), where the comment is pre-filled to

```text
**Environment:**
Operating system:
Firefox version:

**Preconditions:**
text

**Steps to reproduce:**
1. Navigate to: https://www.youtube.com/?app=desktop&hl=it&gl=it
2. Step 2

**Expected Behavior:**
text

**Actual Behavior:**
text

**Notes:**
text

---

Created from webcompat-user-report:53e8e0f1-83d1-4528-b47a-d4d91d59a893
```

r? @ksy36 for the implementation,
r? @softvision-raul-bucata for a review of the template :)