### PR TITLE
A bit more error handling

### DIFF
--- a/src/client/components/user_report_frame.tsx
+++ b/src/client/components/user_report_frame.tsx
@@ -20,7 +20,14 @@ export default function UserReportFrame({ from, to }: UserReportFrameProps) {
         },
       );
 
-      return await res.json();
+      const resData = await res.json();
+      if (res.status == 200) {
+        return resData;
+      } else if (resData.error) {
+        throw new Error(resData.error);
+      } else {
+        throw new Error(`Unexpected sever-side error! status code: ${res.status}`);
+      }
     },
   });
 
@@ -29,8 +36,10 @@ export default function UserReportFrame({ from, to }: UserReportFrameProps) {
       {isLoading && <LoadingSpinner />}
       {error && (
         <div className="error-box">
+          <p>
+            <strong>Error while trying to load the data</strong>:
+          </p>
           <p>{error.message}</p>
-          <p>Are you connected to the Mozilla Corp VPN?</p>
         </div>
       )}
       {data &&

--- a/src/server/helpers/user_reports_transform.ts
+++ b/src/server/helpers/user_reports_transform.ts
@@ -161,9 +161,13 @@ if (parentPort) {
         },
       };
 
-      const { rawReports, rawUrlPatterns } = await fetchUserReports(projectId, paramFrom, paramTo, logger as Logger);
-      const result = transformUserReports(rawReports, rawUrlPatterns, logger as Logger);
-      port.postMessage({ type: "done", result });
+      try {
+        const { rawReports, rawUrlPatterns } = await fetchUserReports(projectId, paramFrom, paramTo, logger as Logger);
+        const result = transformUserReports(rawReports, rawUrlPatterns, logger as Logger);
+        port.postMessage({ type: "done", result });
+      } catch (error) {
+        port.postMessage({ type: "error", error });
+      }
     }
   });
 }

--- a/src/server/routes/user_reports.ts
+++ b/src/server/routes/user_reports.ts
@@ -35,12 +35,18 @@ export default async function handleUserReports(logger: Logger, req: Request, re
       },
       [port1],
     );
-    const results = await new Promise((resolve) => {
+    const results = await new Promise((resolve, reject) => {
       port2.on("message", (msg) => {
-        if (msg.type == "done") {
-          resolve(msg.result);
-        } else if (msg.type == "verbose") {
-          childLogger.verbose(msg.msg);
+        switch (msg.type) {
+          case "done":
+            resolve(msg.result);
+            break;
+          case "verbose":
+            childLogger.verbose(msg.msg);
+            break;
+          case "error":
+            reject(msg.error);
+            break;
         }
       });
     });


### PR DESCRIPTION
This PR does two things:

1. It stops the server crashing if something bad happens in the worker. Instead, it just returns the error as an 500 so it can be shown in the client.
2. If there is an error during loading, we now actually display the error, instead of trying to map the results, resulting in a `results.map is not a function` error message, which doesn't help the user.

r? @ksy36 