### PR TITLE
A bunch of smaller improvmenets...

### DIFF
--- a/src/client/components/user_report_contents.tsx
+++ b/src/client/components/user_report_contents.tsx
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { UserReport } from "../../shared/types";
 import { useState } from "react";
 import LoadingSpinner from "./loading_spinner";
+import { EtpStrictReportDescription, SiteReportDescription } from "../helpers/bugzilla";
 
 type UserReportContentsProps = {
   index: number;
@@ -163,26 +164,9 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                   <td className="actions">
                     <button
                       onClick={() => {
-                        const comment =
-                          "**Environment:**\n" +
-                          "Operating system:\n" +
-                          "Firefox version:\n\n" +
-                          "**Preconditions:**\n" +
-                          "text\n\n" +
-                          "**Steps to reproduce:**\n" +
-                          `1. Navigate to: ${report.url}\n` +
-                          "2. Step 2\n\n" +
-                          "**Expected Behavior:**\n" +
-                          "text\n\n" +
-                          "**Actual Behavior:**\n" +
-                          "text\n\n" +
-                          "**Notes:**\n" +
-                          "text\n\n---\n\n" +
-                          `Created from webcompat-user-report:${report.uuid}`;
-
                         const searchParams = new URLSearchParams([
                           ["bug_file_loc", report.url],
-                          ["comment", comment],
+                          ["comment", SiteReportDescription(report)],
                           ["component", "Site Reports"],
                           ["product", "Web Compatibility"],
                           ["short_desc", `${rootDomain} - CHANGE_ME`],
@@ -194,7 +178,26 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                         window.open(url.toString(), "_blank");
                       }}
                     >
-                      Prepare new Bugzilla bug
+                      Prepare new Site Report bug
+                    </button>
+                    <button
+                      onClick={() => {
+                        const searchParams = new URLSearchParams([
+                          ["bug_file_loc", report.url],
+                          ["comment", EtpStrictReportDescription(report)],
+                          ["dependson", "tp-breakage"],
+                          ["component", "Site Reports"],
+                          ["product", "Web Compatibility"],
+                          ["short_desc", `${rootDomain} - CHANGE_ME`],
+                          ["status_whiteboard", "[webcompat-source:product]"],
+                        ]);
+
+                        const url = new URL("https://bugzilla.mozilla.org/enter_bug.cgi");
+                        url.search = searchParams.toString();
+                        window.open(url.toString(), "_blank");
+                      }}
+                    >
+                      Prepare new ETP Strict bug
                     </button>
                     <button
                       onClick={() => {

--- a/src/client/components/user_report_contents.tsx
+++ b/src/client/components/user_report_contents.tsx
@@ -122,6 +122,10 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                 {report.app_name} {report.app_version} ({report.app_channel}) on {report.os}
               </td>
             </tr>
+            <tr>
+              <td>Tracking Protection</td>
+              <td>{report.tp_status ? report.tp_status : "disabled"}</td>
+            </tr>
             {report.related_bugs?.length > 0 && (
               <tr>
                 <td>Related bugs</td>

--- a/src/client/components/user_report_contents.tsx
+++ b/src/client/components/user_report_contents.tsx
@@ -2,7 +2,12 @@ import { useMutation } from "@tanstack/react-query";
 import { UserReport } from "../../shared/types";
 import { useState } from "react";
 import LoadingSpinner from "./loading_spinner";
-import { EtpStrictReportDescription, SiteReportDescription } from "../helpers/bugzilla";
+import {
+  EtpStrictReportDescription,
+  NewBugDefaultParams,
+  OpenPrefilledBugzillaBug,
+  SiteReportDescription,
+} from "../helpers/bugzilla";
 
 type UserReportContentsProps = {
   index: number;
@@ -113,7 +118,9 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
             )}
             <tr>
               <td>User Agent</td>
-              <td>{report.ua_string}</td>
+              <td>
+                {report.app_name} {report.app_version} ({report.app_channel}) on {report.os}
+              </td>
             </tr>
             {report.related_bugs?.length > 0 && (
               <tr>
@@ -164,37 +171,19 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                   <td className="actions">
                     <button
                       onClick={() => {
-                        const searchParams = new URLSearchParams([
-                          ["bug_file_loc", report.url],
-                          ["comment", SiteReportDescription(report)],
-                          ["component", "Site Reports"],
-                          ["product", "Web Compatibility"],
-                          ["short_desc", `${rootDomain} - CHANGE_ME`],
-                          ["status_whiteboard", "[webcompat-source:product]"],
-                        ]);
-
-                        const url = new URL("https://bugzilla.mozilla.org/enter_bug.cgi");
-                        url.search = searchParams.toString();
-                        window.open(url.toString(), "_blank");
+                        const searchParams = NewBugDefaultParams(report, rootDomain);
+                        searchParams.append("comment", SiteReportDescription(report));
+                        OpenPrefilledBugzillaBug(searchParams);
                       }}
                     >
                       Prepare new Site Report bug
                     </button>
                     <button
                       onClick={() => {
-                        const searchParams = new URLSearchParams([
-                          ["bug_file_loc", report.url],
-                          ["comment", EtpStrictReportDescription(report)],
-                          ["dependson", "tp-breakage"],
-                          ["component", "Site Reports"],
-                          ["product", "Web Compatibility"],
-                          ["short_desc", `${rootDomain} - CHANGE_ME`],
-                          ["status_whiteboard", "[webcompat-source:product]"],
-                        ]);
-
-                        const url = new URL("https://bugzilla.mozilla.org/enter_bug.cgi");
-                        url.search = searchParams.toString();
-                        window.open(url.toString(), "_blank");
+                        const searchParams = NewBugDefaultParams(report, rootDomain);
+                        searchParams.append("comment", EtpStrictReportDescription(report));
+                        searchParams.append("dependson", "tp-breakage");
+                        OpenPrefilledBugzillaBug(searchParams);
                       }}
                     >
                       Prepare new ETP Strict bug

--- a/src/client/helpers/bugzilla.tsx
+++ b/src/client/helpers/bugzilla.tsx
@@ -12,15 +12,41 @@ function trimStartAll(input: string): string {
 }
 
 /**
+ * Builds the default URLSearchParams used to file a new bug and returns it so
+ * it can be extended.
+ */
+export function NewBugDefaultParams(report: UserReport, rootDomain: string): URLSearchParams {
+  return new URLSearchParams([
+    ["bug_file_loc", report.url],
+    ["component", "Site Reports"],
+    ["op_sys", `${report.os}`],
+    ["product", "Web Compatibility"],
+    ["rep_platform", "Desktop"],
+    ["short_desc", `${rootDomain} - CHANGE_ME`],
+    ["status_whiteboard", "[webcompat-source:product]"],
+    ["version", `Firefox ${report.app_major_version}`],
+  ]);
+}
+
+/**
+ * Opens a new tab/window to Bugzilla with a prefilled bug form
+ */
+export function OpenPrefilledBugzillaBug(searchParams: URLSearchParams) {
+  const url = new URL("https://bugzilla.mozilla.org/enter_bug.cgi");
+  url.search = searchParams.toString();
+  window.open(url.toString(), "_blank");
+}
+
+/**
  * Generates a pre-filled Bugzilla comment for a Site Report issue
  */
 export function SiteReportDescription(report: UserReport): string {
   return trimStartAll(`**Environment:**
-    Operating system:
-    Firefox version:
+    Operating system: ${report.os}
+    Firefox version: ${report.app_name} ${report.app_version} (${report.app_channel})
 
     **Preconditions:**
-    text
+    - Clean profile
 
     **Steps to reproduce:**
     1. Navigate to: ${report.url}
@@ -47,8 +73,8 @@ export function SiteReportDescription(report: UserReport): string {
  */
 export function EtpStrictReportDescription(report: UserReport): string {
   return trimStartAll(`**Environment:**
-    Operating system:
-    Firefox version:
+    Operating system: ${report.os}
+    Firefox version: ${report.app_name} ${report.app_version} (${report.app_channel})
 
     **Preconditions:**
     - ETP set to STRICT

--- a/src/client/helpers/bugzilla.tsx
+++ b/src/client/helpers/bugzilla.tsx
@@ -1,0 +1,74 @@
+import { UserReport } from "../../shared/types";
+
+/**
+ * Used here only to un-indent multi-line strings, because I refuse to have
+ * the description templates strings in here with weird indentations.
+ */
+function trimStartAll(input: string): string {
+  return input
+    .split("\n")
+    .map((l) => l.trimStart())
+    .join("\n");
+}
+
+/**
+ * Generates a pre-filled Bugzilla comment for a Site Report issue
+ */
+export function SiteReportDescription(report: UserReport): string {
+  return trimStartAll(`**Environment:**
+    Operating system:
+    Firefox version:
+
+    **Preconditions:**
+    text
+
+    **Steps to reproduce:**
+    1. Navigate to: ${report.url}
+    2. Step 2
+
+    **Expected Behavior:**
+    text
+
+    **Actual Behavior:**
+    text
+
+    **Notes:**
+    - Reproducible on the latest Firefox Release and Nightly
+    - Reproducible regardless of the ETP setting
+    - Works as expected using Chrome
+
+    ---
+
+    Created from webcompat-user-report:${report.uuid}`);
+}
+
+/**
+ * Generates a pre-filled Bugzilla comment for a ETP Strict compat issue
+ */
+export function EtpStrictReportDescription(report: UserReport): string {
+  return trimStartAll(`**Environment:**
+    Operating system:
+    Firefox version:
+
+    **Preconditions:**
+    - ETP set to STRICT
+    - Clean profile
+
+    **Steps to reproduce:**
+    1. Navigate to: ${report.url}
+    2. Step 2
+
+    **Expected Behavior:**
+    text
+
+    **Actual Behavior:**
+    text
+
+    **Notes:**
+    - Not reproduciblewith ETP STANDARD/turned OFF (both Normal and Private Browsing)
+    - Reproducible on the latest Nightly
+
+    ---
+
+    Created from webcompat-user-report:${report.uuid}`);
+}

--- a/src/server/helpers/user_reports_transform.ts
+++ b/src/server/helpers/user_reports_transform.ts
@@ -22,6 +22,7 @@ export async function fetchUserReports(projectId: string, paramFrom: string, par
           CAST(reports.submission_timestamp AS DATETIME) AS reported_at,
           reports.client_info.app_display_version AS app_version,
           reports.metrics.string.broken_site_report_breakage_category AS breakage_category,
+          reports.metrics.string.broken_site_report_tab_info_antitracking_block_list AS tp_status,
           reports.metrics.text2.broken_site_report_browser_info_app_default_useragent_string as ua_string,
           reports.metrics.text2.broken_site_report_description AS comments,
           reports.metrics.url2.broken_site_report_url AS url,

--- a/src/server/helpers/user_reports_transform.ts
+++ b/src/server/helpers/user_reports_transform.ts
@@ -27,7 +27,8 @@ export async function fetchUserReports(projectId: string, paramFrom: string, par
           reports.metrics.url2.broken_site_report_url AS url,
           reports.normalized_app_name AS app_name,
           reports.normalized_channel AS app_channel,
-          reports.normalized_os AS os,
+          reports.metadata.user_agent.os AS os,
+          reports.metadata.user_agent.version AS app_major_version,
           ARRAY(
             SELECT label
             FROM webcompat_user_reports.labels

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,6 +12,7 @@ export type UserReport = {
   prob: number;
   related_bugs: RelatedBug[];
   reported_at: Date;
+  tp_status?: string;
   translated_comments?: string;
   translated_from?: string;
   ua_string: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,17 +1,22 @@
 export type UserReport = {
-  uuid: string;
-  reported_at: Date;
-  url: string;
+  app_channel: string;
+  app_major_version: string;
+  app_name: string;
+  app_version: string;
   breakage_category?: string;
   comments: string;
-  ua_string: string;
-  related_bugs: RelatedBug[];
+  has_actions: boolean;
   labels: string[];
+  os: string;
   prediction: string;
   prob: number;
-  has_actions: boolean;
+  related_bugs: RelatedBug[];
+  reported_at: Date;
   translated_comments?: string;
   translated_from?: string;
+  ua_string: string;
+  url: string;
+  uuid: string;
 };
 
 export type RelatedBug = {


### PR DESCRIPTION
... that I want to ship before my PTO.

This PR has three commits doing a bunch of things:

- I reworked the templates to match the better versions provided by Raul on Slack. This also contains a bit of refactoring to split away all the Bugzilla-prefil-related stuff.
- I added a second Bugzilla button that has a slightly different template for filing ETP issues. This also sets the `tp-breakage` dependency.
- The Operating System and Firefox versions are now pre-filled - both in the template, but also in the dedicated fields Bugzilla has for that. Note that it might show all Windows 11 users as Windows 10 - I'm trying to figure out if that's something we can fix
- I added the ETP status to the dashboard as requested.

r? @ksy36 