### PR TITLE
File ETP bugs in Core :: Privacy: Site Reports

### DIFF
--- a/src/client/components/user_report_contents.tsx
+++ b/src/client/components/user_report_contents.tsx
@@ -155,10 +155,25 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                         const searchParams = new URLSearchParams([
                           ["bug_file_loc_type", "allwordssubstr"],
                           ["bug_file_loc", rootDomain],
-                          ["component", "Site Reports"],
-                          ["product", "Web Compatibility"],
                           ["query_format", "advanced"],
                           ["resolution", "---"],
+                          ["j_top", "OR"],
+                          ["f1", "OP"],
+                          ["o2", "equals"],
+                          ["f2", "product"],
+                          ["v2", "Web Compatibility"],
+                          ["o3", "equals"],
+                          ["f3", "component"],
+                          ["v3", "Site Reports"],
+                          ["f4", "CP"],
+                          ["f5", "OP"],
+                          ["o6", "equals"],
+                          ["f6", "product"],
+                          ["v6", "Web Compatibility"],
+                          ["o7", "equals"],
+                          ["f7", "component"],
+                          ["v7", "Privacy: Site Reports"],
+                          ["f8", "CP"],
                         ]);
 
                         const url = new URL("https://bugzilla.mozilla.org/buglist.cgi");
@@ -176,6 +191,9 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                     <button
                       onClick={() => {
                         const searchParams = NewBugDefaultParams(report, rootDomain);
+                        searchParams.append("product", "Web Compatibility");
+                        searchParams.append("component", "Site Reports");
+
                         searchParams.append("comment", SiteReportDescription(report));
                         OpenPrefilledBugzillaBug(searchParams);
                       }}
@@ -185,6 +203,8 @@ export default function UserReportContents({ index, report, rootDomain }: UserRe
                     <button
                       onClick={() => {
                         const searchParams = NewBugDefaultParams(report, rootDomain);
+                        searchParams.append("product", "Web Compatibility");
+                        searchParams.append("component", "Privacy: Site Reports");
                         searchParams.append("comment", EtpStrictReportDescription(report));
                         searchParams.append("dependson", "tp-breakage");
                         OpenPrefilledBugzillaBug(searchParams);

--- a/src/client/helpers/bugzilla.tsx
+++ b/src/client/helpers/bugzilla.tsx
@@ -18,9 +18,7 @@ function trimStartAll(input: string): string {
 export function NewBugDefaultParams(report: UserReport, rootDomain: string): URLSearchParams {
   return new URLSearchParams([
     ["bug_file_loc", report.url],
-    ["component", "Site Reports"],
     ["op_sys", `${report.os}`],
-    ["product", "Web Compatibility"],
     ["rep_platform", "Desktop"],
     ["short_desc", `${rootDomain} - CHANGE_ME`],
     ["status_whiteboard", "[webcompat-source:product]"],


### PR DESCRIPTION
Also list known ETP bugs when searching for existing reports on the given domain.